### PR TITLE
An annotation title should never be null

### DIFF
--- a/src/githubChecksFormatter.js
+++ b/src/githubChecksFormatter.js
@@ -39,7 +39,7 @@ function annotationsForResults(results) {
             ? annotationLevel.WARNING
             : annotationLevel.FAILURE,
         message: message.message,
-        title: message.ruleId,
+        title: message.ruleId || "Eslint fatal error",
       };
 
       annotations.push(annotation);


### PR DESCRIPTION
Github will reject an update with an annotation in it who's title is `null`. It can happen that the eslint rule id is null when you have hit an error before any rules can be run (like a parse error).